### PR TITLE
Fixing issue #24

### DIFF
--- a/classes/message.rb
+++ b/classes/message.rb
@@ -26,7 +26,7 @@ class Message
 
   def initialize(sender:, conversation:, date_sent:, content:)
     @sender = sender.to_sym
-    @conversation = conversation.to_sym
+    @conversation = conversation
     @date_sent = date_sent
     @content = content
     @words = content.split(' ')


### PR DESCRIPTION
I think it was the inclusion of my refactored code in #17 that introduced the bug and not #23. This should fix the issue by storing conversation names as strings instead of symbols. 

@thnukid - it would be great if you could test it with the messages that raised the original exception. Sorry for the trouble.

If this is the fix, #25 can be reverted